### PR TITLE
Avoid obsolete usage of NLog.Config

### DIFF
--- a/example-project/Program.cs
+++ b/example-project/Program.cs
@@ -8,7 +8,9 @@
 using NLog;
 
 // Configure NLog to color properties based on their type
-NLog.Config.ConfigurationItemFactory.Default.ValueFormatter = new BetterStack.Logs.NLog.ColorValueFormatter();
+NLog.LogManager.Setup().SetupSerialization(
+    setupBuilder => setupBuilder.RegisterValueFormatter(new BetterStack.Logs.NLog.ColorValueFormatter())
+);
 
 // Create logger for current class
 var logger = LogManager.GetCurrentClassLogger();

--- a/example-project/README.md
+++ b/example-project/README.md
@@ -104,7 +104,9 @@ If you'd like your logged properties to be colored by their type, include follow
 
 ```csharp
 // Configure NLog to color properties based on their type
-NLog.Config.ConfigurationItemFactory.Default.ValueFormatter = new BetterStack.Logs.NLog.ColorValueFormatter();
+NLog.LogManager.Setup().SetupSerialization(
+    setupBuilder => setupBuilder.RegisterValueFormatter(new BetterStack.Logs.NLog.ColorValueFormatter())
+);
 ```
 
 ### Filter logs


### PR DESCRIPTION
The current approach is marked as obsolete in NLog 5.0:

![image](https://github.com/BetterStackHQ/logs-client-nlog/assets/10008612/8ba2eded-8438-4a8c-a6cc-5e8b15410ad7)

Setting the formatter via `NLog.LogManager.Setup()` works in previous versions of NLog as well (tested on 4.7.15).

---

After merge, I'll update our docs as well: https://betterstack.com/docs/logs/net-c/#3-start-logging No release necessary, since the library code wasn't changes.